### PR TITLE
fix build error for older versions of Xcode

### DIFF
--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -31,7 +31,7 @@ struct StatsCommand: ParsableCommand {
     @Option(
         name: [.long, .short],
         default: .lines,
-        help: ArgumentHelp("The metric over which to aggregate. One of \(CodeCov.AggregateProperty.allCases.map(\.rawValue))")
+        help: ArgumentHelp("The metric over which to aggregate. One of \(CodeCov.AggregateProperty.allCases.map { $0.rawValue })")
     )
     var metric: CodeCov.AggregateProperty
 


### PR DESCRIPTION
was getting an error when attempting to build using Xcode's 11.2.1 toolchain

```
Sources/swift-test-codecov/main.swift:34:113: error: type of expression is ambiguous without more context
        help: ArgumentHelp("The metric over which to aggregate. One of \(CodeCov.AggregateProperty.allCases.map(\.rawValue))")
                                                                                                                ^~~~~~~~~~
```