### PR TITLE
Update the swift-argument-parser to version 0.2.0. 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
+          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -7,26 +7,30 @@ let package = Package(
     name: "swift-test-codecov",
     products: [
         .executable(name: "swift-test-codecov", targets: ["swift-test-codecov"]),
-        .library(name: "SwiftTestCodecovLib", targets: ["SwiftTestCodecovLib"])
+        .library(name: "SwiftTestCodecovLib", targets: ["SwiftTestCodecovLib"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.0.6")),
-        .package(url: "https://github.com/mattpolzin/TextTable.git", .branch("swift-5"))
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/mattpolzin/TextTable.git", .branch("swift-5")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "swift-test-codecov",
-            dependencies: ["SwiftTestCodecovLib", "ArgumentParser", "TextTable"]),
+            dependencies: ["SwiftTestCodecovLib", "ArgumentParser", "TextTable"]
+        ),
         .testTarget(
             name: "swift-test-codecovTests",
-            dependencies: ["swift-test-codecov"]),
+            dependencies: ["swift-test-codecov"]
+        ),
         .target(
             name: "SwiftTestCodecovLib",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "SwiftTestCodecovLibTests",
-            dependencies: ["SwiftTestCodecovLib"])
+            dependencies: ["SwiftTestCodecovLib"]
+        ),
     ]
 )

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -80,7 +80,7 @@ struct StatsCommand: ParsableCommand {
             .fileCoverages(for: aggProperty)
             .filter { filename, _ in
                 includeDependencies ? true : !isDependencyPath(filename)
-            }
+        }
 
         let totalCountOfProperty = coveragePerFile.reduce(0) { tot, next in
             tot + next.value.count

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -30,7 +30,6 @@ struct StatsCommand: ParsableCommand {
 
     @Option(
         name: [.long, .short],
-        // default: .lines,
         help: ArgumentHelp("The metric over which to aggregate. One of "
             + CodeCov.AggregateProperty.allCases.map { $0.rawValue }.joined(separator: ", "))
     )
@@ -38,7 +37,6 @@ struct StatsCommand: ParsableCommand {
 
     @Option(
         name: [.customLong("minimum"), .customShort("v")],
-        // default: 0,
         help: ArgumentHelp(
             "The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1.",
             valueName: "minimum-coverage"

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -57,7 +57,7 @@ struct StatsCommand: ParsableCommand {
     var includeDependencies: Bool = false
 
     func validate() throws {
-        guard (0 ... 100).contains(minimumCoverage) else {
+        guard (0...100).contains(minimumCoverage) else {
             throw ValidationError("Minimum coverage must be between 0 and 100 because it represents a percentage.")
         }
     }


### PR DESCRIPTION
This is a great tool. When I tried to add it to my project, I received a version reconciliation error from the Swift Package Manager. 