### PR TITLE
Added tests/no-tests flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ OPTIONS:
                           Set the print format. One of minimal, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
   -d, --dependencies      Include dependencies in code coverage calculation. 
-  -r, --removetestfiles   Removes coverage details for all files containing "Tests" or "test" in their name
+  --tests/--no-tests      Determines whether test files are included in coverage calculation or not. Defaults to --no-tests
   -h, --help              Show help information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ OPTIONS:
                           Set the print format. One of minimal, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
   -d, --dependencies      Include dependencies in code coverage calculation. 
+  -r, --removetestfiles   Removes coverage details for all files containing "Tests" or "test" in their name
   -h, --help              Show help information.
 ```
 

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -34,11 +34,11 @@ public struct Aggregate: Encodable {
         coverage: CodeCov,
         property: CodeCov.AggregateProperty,
         includeDependencies: Bool,
-        stripTestFiles: Bool
+        includeTests: Bool
     ) {
         var coverage = coverage
 
-        if stripTestFiles {
+        if !includeTests {
             var nonTestDataSet = [CodeCov.Data]()
             for datum in coverage.data {
                 let nonTestFiles = datum.files.filter({ file in

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -33,8 +33,13 @@ public struct Aggregate: Encodable {
     public init(
         coverage: CodeCov,
         property: CodeCov.AggregateProperty,
-        includeDependencies: Bool
+        includeDependencies: Bool,
+        stripTestFiles: Bool
     ) {
+        var coverage = coverage
+        if stripTestFiles {
+            coverage.stripAllTestFiles()
+        }
         coveragePerFile = coverage
             .fileCoverages(for: property)
             .filter { filename, _ in

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -42,7 +42,7 @@ public struct Aggregate: Encodable {
             var nonTestDataSet = [CodeCov.Data]()
             for datum in coverage.data {
                 let nonTestFiles = datum.files.filter({ file in
-                    !(file.filename.lowercased().contains("tests") || file.filename.lowercased().contains("test"))
+                    !(file.filename.lowercased().contains("test"))
                 })
                 // If all files in this data instance were tests, ignore it altogether. Else add it to the array.
                 if !nonTestFiles.isEmpty {

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -37,9 +37,22 @@ public struct Aggregate: Encodable {
         stripTestFiles: Bool
     ) {
         var coverage = coverage
+
         if stripTestFiles {
-            coverage.stripAllTestFiles()
+            var nonTestDataSet = [CodeCov.Data]()
+            for datum in coverage.data {
+                let nonTestFiles = datum.files.filter({ file in
+                    !(file.filename.lowercased().contains("tests") || file.filename.lowercased().contains("test"))
+                })
+                // If all files in this data instance were tests, ignore it altogether. Else add it to the array.
+                if !nonTestFiles.isEmpty {
+                    nonTestDataSet.append(CodeCov.Data(files: nonTestFiles))
+                }
+            }
+            // Create a new CodeCov instance from the earlier one, minus the test files
+            coverage = CodeCov(version: coverage.version, type: coverage.type, data: nonTestDataSet)
         }
+
         coveragePerFile = coverage
             .fileCoverages(for: property)
             .filter { filename, _ in

--- a/Sources/SwiftTestCodecovLib/CodeCov.swift
+++ b/Sources/SwiftTestCodecovLib/CodeCov.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct CodeCov: Decodable {
     public let version: String
     public let type: String
-    public var data: [Data]
+    public let data: [Data]
 
     public func fileCoverages(for property: AggregateProperty) -> [String: File.Coverage] {
         return Dictionary(uniqueKeysWithValues: data
@@ -20,26 +20,8 @@ public struct CodeCov: Decodable {
         )
     }
 
-    /// Removes all files containing "Tests" or "Test" in their names from coverage result
-    public mutating func stripAllTestFiles() {
-        var processedData = [Data]()
-        for datum in data {
-            var datumCopy = datum
-            datumCopy.stripTestFiles()
-            processedData.append(datumCopy)
-        }
-        self.data = processedData
-    }
-
     public struct Data: Decodable {
-        public var files: [File]
-
-        /// Removes all files containing "Tests" or "Test" in their names from coverage result
-        mutating func stripTestFiles() {
-            files = files.filter({ file in
-                !(file.filename.lowercased().contains("tests") || file.filename.lowercased().contains("test"))
-            })
-        }
+        public let files: [File]
     }
 
     public struct File: Decodable {

--- a/Sources/SwiftTestCodecovLib/CodeCov.swift
+++ b/Sources/SwiftTestCodecovLib/CodeCov.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct CodeCov: Decodable {
     public let version: String
     public let type: String
-    public let data: [Data]
+    public var data: [Data]
 
     public func fileCoverages(for property: AggregateProperty) -> [String: File.Coverage] {
         return Dictionary(uniqueKeysWithValues: data
@@ -20,8 +20,26 @@ public struct CodeCov: Decodable {
         )
     }
 
+    /// Removes all files containing "Tests" or "Test" in their names from coverage result
+    public mutating func stripAllTestFiles() {
+        var processedData = [Data]()
+        for datum in data {
+            var datumCopy = datum
+            datumCopy.stripTestFiles()
+            processedData.append(datumCopy)
+        }
+        self.data = processedData
+    }
+
     public struct Data: Decodable {
-        public let files: [File]
+        public var files: [File]
+
+        /// Removes all files containing "Tests" or "Test" in their names from coverage result
+        mutating func stripTestFiles() {
+            files = files.filter({ file in
+                !(file.filename.lowercased().contains("tests") || file.filename.lowercased().contains("test"))
+            })
+        }
     }
 
     public struct File: Decodable {

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -84,10 +84,11 @@ struct StatsCommand: ParsableCommand {
     var includeDependencies: Bool = false
 
     @Flag(
-        name: [.customLong("removetestfiles"), .customShort("r")],
-        help: ArgumentHelp("Strips test cases from coverage report")
+        name: [.customLong("tests")],
+        inversion: .prefixedNo,
+        help: ArgumentHelp("Determines whether test files are included in coverage calculation.")
     )
-    var stripTestFiles: Bool = false
+    var includeTests: Bool = false
     
     func validate() throws {
         guard (0...100).contains(minimumCoverage) else {
@@ -108,7 +109,7 @@ struct StatsCommand: ParsableCommand {
             coverage: codeCoverage,
             property: aggProperty,
             includeDependencies: includeDependencies,
-            stripTestFiles: stripTestFiles
+            includeTests: includeTests
         )
 
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -83,6 +83,12 @@ struct StatsCommand: ParsableCommand {
     )
     var includeDependencies: Bool = false
 
+    @Flag(
+        name: [.customLong("removetestfiles"), .customShort("r")],
+        help: ArgumentHelp("Strips test cases from coverage report")
+    )
+    var stripTestFiles: Bool = false
+    
     func validate() throws {
         guard (0...100).contains(minimumCoverage) else {
             throw ValidationError("Minimum coverage must be between 0 and 100 because it represents a percentage.")
@@ -101,7 +107,8 @@ struct StatsCommand: ParsableCommand {
         let aggregateCoverage = Aggregate(
             coverage: codeCoverage,
             property: aggProperty,
-            includeDependencies: includeDependencies
+            includeDependencies: includeDependencies,
+            stripTestFiles: stripTestFiles
         )
 
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)


### PR DESCRIPTION
Since the coverage data contains file names only, test cases themselves are also being included in the final coverage report

Added a flag to strip all files containing `test` or `tests` in their names, to reflect the coverage % of only the main target.

The files are removed in `run()` itself, so that they are not processed further file generating the report