### PR TITLE
Support local deps alternative

### DIFF
--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -6,9 +6,14 @@
 
 import Foundation
 
-public func isDependencyPath(_ path: String) -> Bool {
-    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-    let projectDir = cwd.lastPathComponent
+public func isDependencyPath(_ path: String, projectName: String? = nil) -> Bool {
+    let projectDir: String
+    if let projectName = projectName {
+        projectDir = projectName
+    } else {
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        projectDir = cwd.lastPathComponent
+    }
     let isLocalDependency = projectDir != "" && !path.contains(projectDir)
     return isLocalDependency || path.contains(".build/")
 }
@@ -37,7 +42,8 @@ public struct Aggregate: Encodable {
         coverage: CodeCov,
         property: CodeCov.AggregateProperty,
         includeDependencies: Bool,
-        includeTests: Bool
+        includeTests: Bool,
+        projectName: String? = nil
     ) {
         var coverage = coverage
 
@@ -59,7 +65,7 @@ public struct Aggregate: Encodable {
         coveragePerFile = coverage
             .fileCoverages(for: property)
             .filter { filename, _ in
-                includeDependencies ? true : !isDependencyPath(filename)
+                includeDependencies ? true : !isDependencyPath(filename, projectName: projectName)
             }
 
         let total = coveragePerFile.reduce(0) { tot, next in

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -38,12 +38,21 @@ struct StatsCommand: ParsableCommand {
 
     @Argument(
         help: ArgumentHelp(
-            "the location of the JSON file output by `swift test --enable-code-coverage`.",
+            "The location of the JSON file output by `swift test --enable-code-coverage`.",
             discussion: codecovFileDiscussion,
             valueName: "codecov-filepath"
         )
     )
     var codecovFile: String
+
+    @Option(
+        help: ArgumentHelp(
+            "The name of the target project.",
+            discussion: "If specified, used to determine which source files being tested are outside of this project (local dependencies).",
+            valueName: "project-name"
+        )
+    )
+    var projectName: String?
 
     @Option(
         name: [.long, .short],
@@ -110,7 +119,8 @@ struct StatsCommand: ParsableCommand {
             coverage: codeCoverage,
             property: aggProperty,
             includeDependencies: includeDependencies,
-            includeTests: includeTests
+            includeTests: includeTests,
+            projectName: projectName
         )
 
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
@@ -156,7 +166,7 @@ extension StatsCommand {
 
         let fileCoverages: [CoverageTriple] = aggregateCoverage.coveragePerFile.map {
             (
-                dependency: isDependencyPath($0.key),
+                dependency: isDependencyPath($0.key, projectName: projectName),
                 filename: URL(fileURLWithPath: $0.key).lastPathComponent,
                 coverage: $0.value.percent
             )

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -123,6 +123,13 @@ struct StatsCommand: ParsableCommand {
             projectName: projectName
         )
 
+        if aggregateCoverage.totalCount == 0 {
+            print("")
+            print("No coverage was analyzed.")
+            print("Double check that you are either running this tool from the root of your target project or else you've specified a project-name that has the exact name of the root folder of your target project -- otherwise, all files may be filtered out as belonging to other projects (dependencies).")
+            return
+        }
+
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
 
         if !passed && printFormat == .table {


### PR DESCRIPTION
Support specifying a project name for local dependency detection rather than relying on the current working directory being the source-code root of the target project.