### PR TITLE
Add Makefile to ease installation on MacOS 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+prefix ?= /usr/local
+bindir = $(prefix)/bin
+libdir = $(prefix)/lib
+
+build:
+	swift build -c release --disable-sandbox
+
+install: build
+	install -d "$(bindir)" "$(libdir)"
+	install ".build/release/swift-test-codecov" "$(bindir)"
+
+uninstall:
+	rm -rf "$(bindir)/swift-test-codecov"
+
+clean:
+	rm -rf .build
+
+.PHONY: build install uninstall clean

--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ OPTIONS:
 
 ## Building Docker Image
 Run `docker build -t swift-test-codecov .` to build the docker image.
+
+## Installing with Make
+
+Run `sudo make install` to install on MacOS.
+
+Run `sudo make uninstall` to uninstall.


### PR DESCRIPTION
This also enables easier Homebrew installation. I'm currently using it with a private Homebrew Tap, but I'd love to add it to the Homebrew repository if you're interested.