### PR TITLE
Add print-format  for unformatted total coverage result

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OPTIONS:
                           Determines whether dependencies are included in code coverage calculation. (default: false)
   --tests/--no-tests      Determines whether test files are included in coverage calculation. (default: false)
   --warn-missing-tests/--no-warn-missing-tests
-                          Determines whether a warning will be displayed for 0% coverage. (Does not apply to print-formats `numeric` and `json`.) (default: true)
+                          Determines whether a warning will be displayed if no coverage data is available. (Does not apply to print-formats `numeric` and `json`.) (default: true)
   -h, --help              Show help information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ OPTIONS:
   -v, --minimum <minimum-coverage>
                           The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
   --explain-failure/--no-explain-failure
-                          Determines whether a message will be displayed if the minimum coverage threshold was not met. (default: true)
+                          Determines whether a message will be displayed if the minimum coverage threshold was not met. (The `json` print-format will never display messages and will always be parsable
+                          JSON.) (default: true)
   -p, --print-format <print-format>
                           Set the print format. One of minimal, numeric, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
@@ -41,7 +42,8 @@ OPTIONS:
                           Determines whether dependencies are included in code coverage calculation. (default: false)
   --tests/--no-tests      Determines whether test files are included in coverage calculation. (default: false)
   --warn-missing-tests/--no-warn-missing-tests
-                          Determines whether a warning will be displayed if no coverage data is available. (default: true)
+                          Determines whether a warning will be displayed if no coverage data is available. (The `json` print-format will never display messages and will always be parsable JSON.)
+                          (default: true)
   -h, --help              Show help information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OVERVIEW: Analyze Code Coverage Metrics
 
 Ingest Code Coverage Metrics provided by `swift test --enable-code-coverage` and provide some high level analysis.
 
-USAGE: swift-test-codecov <codecov-filepath> [--project-name <project-name>] [--metric <metric>] [--minimum <minimum-coverage>] [--print-format <print-format>] [--sort <sort>] [--dependencies] [--no-dependencies] [--tests] [--no-tests]
+USAGE: swift-test-codecov <options>
 
 ARGUMENTS:
   <codecov-filepath>      The location of the JSON file output by `swift test --enable-code-coverage`. 
@@ -32,12 +32,16 @@ OPTIONS:
   -m, --metric <metric>   The metric over which to aggregate. One of lines, functions, instantiations (default: lines)
   -v, --minimum <minimum-coverage>
                           The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
+  --explain-failure/--no-explain-failure
+                          Determines whether a message will be displayed if the minimum coverage threshold was not met. (Does not apply to print-formats `numeric` and `json`.) (default: true)
   -p, --print-format <print-format>
                           Set the print format. One of minimal, numeric, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
   --dependencies/--no-dependencies
                           Determines whether dependencies are included in code coverage calculation. (default: false)
   --tests/--no-tests      Determines whether test files are included in coverage calculation. (default: false)
+  --warn-missing-tests/--no-warn-missing-tests
+                          Determines whether a warning will be displayed for 0% coverage. (Does not apply to print-formats `numeric` and `json`.) (default: true)
   -h, --help              Show help information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OPTIONS:
   -v, --minimum <minimum-coverage>
                           The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
   --explain-failure/--no-explain-failure
-                          Determines whether a message will be displayed if the minimum coverage threshold was not met. (Does not apply to print-formats `numeric` and `json`.) (default: true)
+                          Determines whether a message will be displayed if the minimum coverage threshold was not met. (default: true)
   -p, --print-format <print-format>
                           Set the print format. One of minimal, numeric, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
@@ -41,7 +41,7 @@ OPTIONS:
                           Determines whether dependencies are included in code coverage calculation. (default: false)
   --tests/--no-tests      Determines whether test files are included in coverage calculation. (default: false)
   --warn-missing-tests/--no-warn-missing-tests
-                          Determines whether a warning will be displayed if no coverage data is available. (Does not apply to print-formats `numeric` and `json`.) (default: true)
+                          Determines whether a warning will be displayed if no coverage data is available. (default: true)
   -h, --help              Show help information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,27 @@ The library has a pretty small and straight forward interface. I have not had ti
 The tool is meant to be run from the root folder of your project. The executable can be anywhere but the current working directory is important for the tool to accurately identify which files are part of your project and which files are part of a dependency's project.
 
 ```
-USAGE: swift-test-codecov <codecov-filepath> [--metric <metric>] [--minimum <minimum-coverage>] [--print-format <print-format>] [--sort <sort>] [--dependencies] [--no-dependencies] [--tests] [--no-tests]
+OVERVIEW: Analyze Code Coverage Metrics
+
+Ingest Code Coverage Metrics provided by `swift test --enable-code-coverage` and provide some high level analysis.
+
+USAGE: swift-test-codecov <codecov-filepath> [--project-name <project-name>] [--metric <metric>] [--minimum <minimum-coverage>] [--print-format <print-format>] [--sort <sort>] [--dependencies] [--no-dependencies] [--tests] [--no-tests]
 
 ARGUMENTS:
-  <codecov-filepath>      the location of the JSON file output by `swift test --enable-code-coverage`. 
+  <codecov-filepath>      The location of the JSON file output by `swift test --enable-code-coverage`. 
         You will find this in the build directory.
 
         For example, if you've just performed a debug build, the file will be located at `./.build/debug/codecov/<package-name>.json`.
 
 OPTIONS:
+  --project-name <project-name>
+                          The name of the target project. 
+        If specified, used to determine which source files being tested are outside of this project (local dependencies).
   -m, --metric <metric>   The metric over which to aggregate. One of lines, functions, instantiations (default: lines)
   -v, --minimum <minimum-coverage>
-                          The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in
-                          exit code 1. (default: 0)
+                          The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
   -p, --print-format <print-format>
-                          Set the print format. One of minimal, table, json (default: minimal)
+                          Set the print format. One of minimal, numeric, table, json (default: minimal)
   -s, --sort <sort>       Set the sort order for the coverage table. One of filename, +cov, -cov (default: filename)
   --dependencies/--no-dependencies
                           Determines whether dependencies are included in code coverage calculation. (default: false)
@@ -40,6 +46,6 @@ Run `docker build -t swift-test-codecov .` to build the docker image.
 
 ## Installing with Make
 
-Run `sudo make install` to install on MacOS.
+Run `sudo make install` to install.
 
 Run `sudo make uninstall` to uninstall.

--- a/Sources/SwiftTestCodecovLib/CodeCov.swift
+++ b/Sources/SwiftTestCodecovLib/CodeCov.swift
@@ -15,8 +15,10 @@ public struct CodeCov: Decodable {
     public let data: [Data]
 
     public func fileCoverages(for property: AggregateProperty) -> [String: File.Coverage] {
-        return Dictionary(uniqueKeysWithValues: data
-            .first!
+        guard let first = data.first else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: first
             .files
             .map { ($0.filename, $0.summary.coverage(for: property)) }
         )

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -177,9 +177,7 @@ extension StatsCommand {
     }
 
     func printMinimal(_ aggregateCoverage: Aggregate) {
-        print("")
         print(aggregateCoverage.formattedOverallCoveragePercent)
-        print("")
     }
     
     func printNumeric(_ aggregateCoverage: Aggregate) {

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -111,7 +111,7 @@ struct StatsCommand: ParsableCommand {
     @Flag(
         name: [.customLong("warn-missing-tests")],
         inversion: .prefixedNo,
-        help: ArgumentHelp("Determines whether a warning will be displayed for 0% coverage. (Does not apply to print-formats `numeric` and `json`.)")
+        help: ArgumentHelp("Determines whether a warning will be displayed if no coverage data is available. (Does not apply to print-formats `numeric` and `json`.)")
     )
     var warnMissingTests: Bool = true
     

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -74,7 +74,7 @@ struct StatsCommand: ParsableCommand {
     @Flag(
         name: [.customLong("explain-failure")],
         inversion: .prefixedNo,
-        help: ArgumentHelp("Determines whether a message will be displayed if the minimum coverage threshold was not met.")
+        help: ArgumentHelp("Determines whether a message will be displayed if the minimum coverage threshold was not met. (The `json` print-format will never display messages and will always be parsable JSON.)")
     )
     var explainFailure: Bool = true
 
@@ -111,7 +111,7 @@ struct StatsCommand: ParsableCommand {
     @Flag(
         name: [.customLong("warn-missing-tests")],
         inversion: .prefixedNo,
-        help: ArgumentHelp("Determines whether a warning will be displayed if no coverage data is available.")
+        help: ArgumentHelp("Determines whether a warning will be displayed if no coverage data is available. (The `json` print-format will never display messages and will always be parsable JSON.)")
     )
     var warnMissingTests: Bool = true
     
@@ -138,7 +138,7 @@ struct StatsCommand: ParsableCommand {
             projectName: projectName
         )
 
-        if aggregateCoverage.totalCount == 0 && warnMissingTests {
+        if aggregateCoverage.totalCount == 0 && printFormat != .json && warnMissingTests {
             print("")
             print("No coverage was analyzed.")
             print("")
@@ -147,7 +147,7 @@ struct StatsCommand: ParsableCommand {
 
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
 
-        if !passed && explainFailure {
+        if !passed && printFormat != .json && explainFailure {
             // we don't print the error message out for the minimal or JSON formats.
             print("")
             print("The overall coverage did not meet the minimum threshold of \(minimumCov)%")

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -15,6 +15,7 @@ For example, if you've just performed a debug build, the file will be located at
 /// How to display the results.
 enum PrintFormat: String, CaseIterable, ExpressibleByArgument {
     case minimal
+    case numeric
     case table
     case json
 }
@@ -123,11 +124,10 @@ struct StatsCommand: ParsableCommand {
             projectName: projectName
         )
 
-        if aggregateCoverage.totalCount == 0 {
+        if aggregateCoverage.totalCount == 0 && printFormat != .numeric {
             print("")
             print("No coverage was analyzed.")
             print("Double check that you are either running this tool from the root of your target project or else you've specified a project-name that has the exact name of the root folder of your target project -- otherwise, all files may be filtered out as belonging to other projects (dependencies).")
-            return
         }
 
         let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
@@ -152,6 +152,8 @@ extension StatsCommand {
         switch printFormat {
         case .minimal:
             printMinimal(aggregateCoverage)
+        case .numeric:
+            printNumeric(aggregateCoverage)
         case .table:
             printTable(aggregateCoverage)
         case .json:
@@ -161,6 +163,10 @@ extension StatsCommand {
 
     func printMinimal(_ aggregateCoverage: Aggregate) {
         print(aggregateCoverage.formattedOverallCoveragePercent)
+    }
+    
+    func printNumeric(_ aggregateCoverage: Aggregate) {
+        print(aggregateCoverage.overallCoveragePercent)
     }
 
     func printTable(_ aggregateCoverage: Aggregate) {

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -74,7 +74,7 @@ struct StatsCommand: ParsableCommand {
     @Flag(
         name: [.customLong("explain-failure")],
         inversion: .prefixedNo,
-        help: ArgumentHelp("Determines whether a message will be displayed if the minimum coverage threshold was not met. (Does not apply to print-formats `numeric` and `json`.)")
+        help: ArgumentHelp("Determines whether a message will be displayed if the minimum coverage threshold was not met.")
     )
     var explainFailure: Bool = true
 
@@ -111,7 +111,7 @@ struct StatsCommand: ParsableCommand {
     @Flag(
         name: [.customLong("warn-missing-tests")],
         inversion: .prefixedNo,
-        help: ArgumentHelp("Determines whether a warning will be displayed if no coverage data is available. (Does not apply to print-formats `numeric` and `json`.)")
+        help: ArgumentHelp("Determines whether a warning will be displayed if no coverage data is available.")
     )
     var warnMissingTests: Bool = true
     


### PR DESCRIPTION
For context, I'm using this in two places:

1. To generate a badge using https://github.com/BellumAI/coverage-badge-generator which takes just a percentage number, hence the `numeric` print format.
2. As a table, where I'm using the minimum-version parameter to fail the build. 

Some of our repos currently have no tests, so 0% coverage is valid in our workflows.

I'd still like the ability to generate a coverage delta from a previous print-format `json` run, and display as a table, as well as fail if the coverage number decreased from the previous run. I can do this in a separate utility, or I can PR it into this one. I don't want to presume that you'd like the functionality added, or that you have the time to deal with my PRs. Thoughts?

Thanks again!

Examples:

0% coverage `-p table -v 25`:

```

No coverage was analyzed.
Double check that you are either running this tool from the root of your target project or else you've specified a project-name that has the exact name of the root folder of your target project -- otherwise, all files may be filtered out as belonging to other projects (dependencies).

The overall coverage did not meet the minimum threshold of 25%

Overall Coverage: 0.00%

File              Coverage
----------------- --------
                          
=-=-=-=-=-=-=-=-=         
                 
```

0% coverage `-p numeric`:

```
0.0
```

Some coverage `-p numeric`:

```
82.08695652173913
```