### PR TITLE
Add `--exclude-path` option to filter files based on path with a regex

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Regex",
+        "repositoryURL": "https://github.com/sharplet/Regex.git",
+        "state": {
+          "branch": null,
+          "revision": "76c2b73d4281d77fc3118391877efd1bf972f515",
+          "version": "2.1.1"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/mattpolzin/TextTable.git", .branch("swift-5")),
+        .package(url: "https://github.com/sharplet/Regex.git", .upToNextMinor(from: "2.1.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -26,11 +27,11 @@ let package = Package(
         ),
         .target(
             name: "SwiftTestCodecovLib",
-            dependencies: []
+            dependencies: ["Regex"]
         ),
         .testTarget(
             name: "SwiftTestCodecovLibTests",
-            dependencies: ["SwiftTestCodecovLib"]
+            dependencies: ["SwiftTestCodecovLib", "Regex"]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ OPTIONS:
   --dependencies/--no-dependencies
                           Determines whether dependencies are included in code coverage calculation. (default: false)
   --tests/--no-tests      Determines whether test files are included in coverage calculation. (default: false)
+  -x, --exclude-path <regex>
+                          Regex pattern of full file paths to exclude in coverage calculation. 
+        If specified, used to determine which source files being tested should be excluded. (Example value "View\.swift|Mock\.swift" excludes all files with names ending with `View` or `Mock`.)
   --warn-missing-tests/--no-warn-missing-tests
                           Determines whether a warning will be displayed if no coverage data is available. (The `json` print-format will never display messages and will always be parsable JSON.)
                           (default: true)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ OPTIONS:
   -x, --exclude-path <regex>
                           Regex pattern of full file paths to exclude in coverage calculation. 
         If specified, used to determine which source files being tested should be excluded. (Example value "View\.swift|Mock\.swift" excludes all files with names ending with `View` or `Mock`.)
+
+        If the regular expression cannot be parsed by the system, the application will exit with code 1. An error message will be printed unless the `print-format` is set to `json`, in which case an
+        empty object (`{}`) will be printed.
   --warn-missing-tests/--no-warn-missing-tests
                           Determines whether a warning will be displayed if no coverage data is available. (The `json` print-format will never display messages and will always be parsable JSON.)
                           (default: true)

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -76,7 +76,9 @@ public struct Aggregate: Encodable {
         coveragePerFile = coverage
             .fileCoverages(for: property)
             .filter { filename, _ in
-                includeDependencies ? true : !isDependencyPath(filename, projectName: projectName) && !isExcludedPath(filename, regex: regex)
+                let included = includeDependencies ? true : !isDependencyPath(filename, projectName: projectName)
+                let notExcludedByRegex = !isExcludedPath(filename, regex: regex)
+                return included && notExcludedByRegex
             }
 
         let total = coveragePerFile.reduce(0) { tot, next in

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -16,18 +16,14 @@ public func isDependencyPath(_ path: String, projectName: String? = nil) -> Bool
         projectDir = cwd.lastPathComponent
     }
     let isLocalDependency = projectDir != "" && !path.contains(projectDir)
-    let excludedDependency = isLocalDependency || path.contains(".build/")
-    print("excludedDependency: \(excludedDependency) [\(path)]")
-    return excludedDependency
+    return isLocalDependency || path.contains(".build/")
 }
 
 public func isExcludedPath(_ path: String, regex: Regex?) -> Bool {
     guard let regex else {
         return false
     }
-    let excludedMatch = regex.matches(path)
-    print("excludedMatch: \(excludedMatch) [\(path)]")
-    return excludedMatch
+    return regex.matches(path)
 }
 
 public struct Aggregate: Encodable {

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -154,7 +154,7 @@ struct StatsCommand: ParsableCommand {
             if printFormat == .json {
                 print("{}")
             } else {
-                print("Invalid `exclude-path` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
+                print("Invalid `exclude-path`: unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
             }
             throw ExitCode.failure
         }

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -154,7 +154,7 @@ struct StatsCommand: ParsableCommand {
             if printFormat == .json {
                 print("{}")
             } else {
-                print("Invalid `excludeRegexString` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
+                print("Invalid `exclude-path` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
             }
             throw ExitCode.failure
         }

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -108,6 +108,16 @@ struct StatsCommand: ParsableCommand {
     )
     var includeTests: Bool = false
     
+    @Option(
+        name: [.customLong("exclude-path"), .customShort("x")],
+        help: ArgumentHelp(
+            "Regex pattern of full file paths to exclude in coverage calculation.",
+            discussion: "If specified, used to determine which source files being tested should be excluded. (Example value \"View\\.swift|Mock\\.swift\" excludes all files with names ending with `View` or `Mock`.)",
+            valueName: "regex"
+        )
+    )
+    var excludeRegexString: String?
+    
     @Flag(
         name: [.customLong("warn-missing-tests")],
         inversion: .prefixedNo,
@@ -130,13 +140,20 @@ struct StatsCommand: ParsableCommand {
 
         let codeCoverage = try! Self.jsonDecoder.decode(CodeCov.self, from: data)
 
-        let aggregateCoverage = Aggregate(
-            coverage: codeCoverage,
-            property: aggProperty,
-            includeDependencies: includeDependencies,
-            includeTests: includeTests,
-            projectName: projectName
-        )
+        let aggregateCoverage: Aggregate
+        do {
+            aggregateCoverage = try Aggregate(
+                coverage: codeCoverage,
+                property: aggProperty,
+                includeDependencies: includeDependencies,
+                includeTests: includeTests,
+                excludeRegexString: excludeRegexString,
+                projectName: projectName
+            )
+        } catch {
+            print("Invalid `excludeRegexString` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
+            throw ExitCode.failure
+        }
 
         if aggregateCoverage.totalCount == 0 && printFormat != .json && warnMissingTests {
             print("")

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -112,7 +112,7 @@ struct StatsCommand: ParsableCommand {
         name: [.customLong("exclude-path"), .customShort("x")],
         help: ArgumentHelp(
             "Regex pattern of full file paths to exclude in coverage calculation.",
-            discussion: "If specified, used to determine which source files being tested should be excluded. (Example value \"View\\.swift|Mock\\.swift\" excludes all files with names ending with `View` or `Mock`.)",
+            discussion: "If specified, used to determine which source files being tested should be excluded. (Example value \"View\\.swift|Mock\\.swift\" excludes all files with names ending with `View` or `Mock`.)\n\nIf the regular expression cannot be parsed by the system, the application will exit with code 1. An error message will be printed unless the `print-format` is set to `json`, in which case an empty object (`{}`) will be printed.",
             valueName: "regex"
         )
     )
@@ -151,7 +151,11 @@ struct StatsCommand: ParsableCommand {
                 projectName: projectName
             )
         } catch {
-            print("Invalid `excludeRegexString` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
+            if printFormat == .json {
+                print("{}")
+            } else {
+                print("Invalid `excludeRegexString` unable to parse '\(String(describing: excludeRegexString))' as regular expression.")
+            }
             throw ExitCode.failure
         }
 

--- a/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
+++ b/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
@@ -1,0 +1,25 @@
+//
+//  AggregateTests.swift
+//  
+//
+//  Created by Eric DeLabar on 12/9/22.
+//
+
+import XCTest
+import Regex
+@testable import SwiftTestCodecovLib
+
+final class AggregateTests: XCTestCase {
+
+    func testIsExcludedPath() throws {
+        
+        let helpExampleRegex = Regex("Mock\\.swift|View\\.swift")
+        
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/MyModel.swift", regex: helpExampleRegex))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/View/ViewName.swift", regex: helpExampleRegex))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/Mock/MockName.swift", regex: helpExampleRegex))
+        XCTAssertTrue(isExcludedPath(".build/Sources/Project/MyView.swift", regex: helpExampleRegex))
+        XCTAssertTrue(isExcludedPath(".build/Sources/Project/MyMock.swift", regex: helpExampleRegex))
+    }
+
+}

--- a/Tests/SwiftTestCodecovLibTests/PlaceholderTests.swift
+++ b/Tests/SwiftTestCodecovLibTests/PlaceholderTests.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Mathew Polzin on 8/1/19.
-//
-
-import Foundation


### PR DESCRIPTION
As promised in #14 comments...

The error handling for print-type json was just added, wanted your input before I went too deep there. (I guess alternative would be the empty Aggregate object? `{"overallCoverage":0,"totalCount":0,"coveragePerFile":{}}`)

I'm also not aware of your thoughts on pulling-in extra dependencies, I've used the Regex package before, works well enough.

For my use case, we externalize business logic and then don't unit test SwiftUI Views so I'm hoping to do something like the example `--exclude-path "View\\.swift|Mock\\.swift"` to take care of that. Other coverage tools on other platforms have a similar parameter, so in this case I can duplicate a pattern from our Android app CI workflow.

Thanks again!