### PR TITLE
Feature: Optionally read JSON output of previous run and display coverage deltas

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     products: [
         .executable(name: "swift-test-codecov", targets: ["swift-test-codecov"]),
         .library(name: "SwiftTestCodecovLib", targets: ["SwiftTestCodecovLib"]),
+        .library(name: "SwiftTestCodecovLogic", targets: ["SwiftTestCodecovLogic"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.1")),
@@ -19,11 +20,16 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "swift-test-codecov",
-            dependencies: ["SwiftTestCodecovLib", "ArgumentParser", "TextTable"]
+            dependencies: ["SwiftTestCodecovLib", "SwiftTestCodecovLogic", "ArgumentParser", "TextTable"]
+        ),
+        // Executable targets are not unit testable so this target is necessary to unit test the executable's logic
+        .target(
+            name: "SwiftTestCodecovLogic",
+            dependencies: ["SwiftTestCodecovLib", "TextTable"]
         ),
         .testTarget(
-            name: "swift-test-codecovTests",
-            dependencies: ["swift-test-codecov"]
+            name: "SwiftTestCodecovLogicTests",
+            dependencies: ["SwiftTestCodecovLogic", "SwiftTestCodecovLib"]
         ),
         .target(
             name: "SwiftTestCodecovLib",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ OPTIONS:
   -m, --metric <metric>   The metric over which to aggregate. One of lines, functions, instantiations (default: lines)
   -v, --minimum <minimum-coverage>
                           The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
+  --fail-on-negative-delta/--no-fail-on-negative-delta
+                          When enabled a coverage amount lower than the base will result in exit code 1. (default: false)
+        Requires a previous run's JSON file is passed with option `--base-json-file` or will be treated as `false`.
   --explain-failure/--no-explain-failure
                           Determines whether a message will be displayed if the minimum coverage threshold was not met. (The `json` print-format will never display messages and will always be parsable
                           JSON.) (default: true)
@@ -47,6 +50,10 @@ OPTIONS:
 
         If the regular expression cannot be parsed by the system, the application will exit with code 1. An error message will be printed unless the `print-format` is set to `json`, in which case an
         empty object (`{}`) will be printed.
+  -b, --base-json-file <previous-filepath>
+                          The location of the JSON file output by a previous run of `swift-test-codecov` with the `-p json` print format. 
+        If specified, the `minimal`, `table`, and `json` print formats will include total coverage, and if applicable, file-by-file differences. The `numeric` format will return the difference between
+        the base file and the current run.
   --warn-missing-tests/--no-warn-missing-tests
                           Determines whether a warning will be displayed if no coverage data is available. (The `json` print-format will never display messages and will always be parsable JSON.)
                           (default: true)

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -55,8 +55,20 @@ public struct Aggregate: Codable {
     /// The difference in overallCoverage between this and a different Aggregate provided on initialization.
     public let overallCoverageDelta: Double?
     
+    private let _coveredProperty: CodeCov.AggregateProperty?
+    
     /// The aggregate property that this struct is built on
-    public let coveredProperty: CodeCov.AggregateProperty
+    public var coveredProperty: CodeCov.AggregateProperty { _coveredProperty ?? .lines }
+    
+    enum CodingKeys: String, CodingKey {
+        case coveragePerFile
+        case coverageDeltaPerFile
+        case totalCount
+        case totalCountDelta
+        case overallCoverage
+        case overallCoverageDelta
+        case _coveredProperty = "coveredProperty"
+    }
     
     public init(
         coverage: CodeCov,
@@ -103,10 +115,10 @@ public struct Aggregate: Codable {
             avg + Double(next.value.covered) / Double(total)
         }
         
-        coveredProperty = property
+        _coveredProperty = property
         
         if let base {
-            guard coveredProperty == base.coveredProperty else {
+            guard property == base.coveredProperty else {
                 throw AggregateError.invalidBaseAggregate(base.coveredProperty.rawValue)
             }
             coverageDeltaPerFile = coveragePerFile.delta(base.coveragePerFile)
@@ -137,7 +149,7 @@ extension Aggregate {
         self.totalCountDelta = totalCountDelta
         self.overallCoverage = overallCoverage
         self.overallCoverageDelta = overallCoverageDelta
-        self.coveredProperty = coveredProperty
+        self._coveredProperty = coveredProperty
     }
     
 }

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -26,37 +26,50 @@ public func isExcludedPath(_ path: String, regex: Regex?) -> Bool {
     return regex.matches(path)
 }
 
-public struct Aggregate: Encodable {
+public enum CoverageDelta: Codable, Equatable {
+    case fileAdded(CodeCov.File.Coverage)
+    case fileRemoved
+    case delta(CodeCov.File.Coverage)
+}
+
+public enum AggregateError: Error, Equatable {
+    case invalidBaseAggregate(String)
+}
+
+public struct Aggregate: Codable {
+    
     /// The coverage data per-file.
     public let coveragePerFile: [String: CodeCov.File.Coverage]
+    /// The coverage delta per-file if a difference Aggregate is provided during initialization.
+    public let coverageDeltaPerFile: [String: CoverageDelta]?
+    
     /// The total number of whatever aggregate property is chosen
     ///
     /// For example, the number of lines (in total, not with coverage).
     public let totalCount: Int
+    /// The difference between this and a different Aggregate provided on initialization.
+    public let totalCountDelta: Int?
+    
     /// Overall coverage -- a number between 0.0 and 1.0
     public let overallCoverage: Double
-
-    /// Overall coverage -- a number between 0.0 and 100.0
-    public var overallCoveragePercent: Double {
-        overallCoverage * 100
-    }
-
-    /// A String-formatted coverage percentage, out to two decimal places.
-    public var formattedOverallCoveragePercent: String {
-        "\(String(format: "%.2f", overallCoveragePercent))%"
-    }
-
+    /// The difference in overallCoverage between this and a different Aggregate provided on initialization.
+    public let overallCoverageDelta: Double?
+    
+    /// The aggregate property that this struct is built on
+    public let coveredProperty: CodeCov.AggregateProperty
+    
     public init(
         coverage: CodeCov,
         property: CodeCov.AggregateProperty,
         includeDependencies: Bool,
         includeTests: Bool,
         excludeRegexString: String?,
-        projectName: String? = nil
+        projectName: String? = nil,
+        fromBase base: Aggregate?
     ) throws {
         var coverage = coverage
         
-        let regex = try Regex(string: excludeRegexString)
+        let regex = try Regex(optionalString: excludeRegexString)
 
         if !includeTests {
             var nonTestDataSet = [CodeCov.Data]()
@@ -89,13 +102,151 @@ public struct Aggregate: Encodable {
         overallCoverage = coveragePerFile.reduce(0.0) { avg, next in
             avg + Double(next.value.covered) / Double(total)
         }
+        
+        coveredProperty = property
+        
+        if let base {
+            guard coveredProperty == base.coveredProperty else {
+                throw AggregateError.invalidBaseAggregate(base.coveredProperty.rawValue)
+            }
+            coverageDeltaPerFile = coveragePerFile.delta(base.coveragePerFile)
+            totalCountDelta = totalCount - base.totalCount
+            overallCoverageDelta = overallCoverage - base.overallCoverage
+        } else {
+            coverageDeltaPerFile = nil
+            totalCountDelta = nil
+            overallCoverageDelta = nil
+        }
     }
+}
+
+extension Aggregate {
+    
+    internal init(
+        coveragePerFile: [String : CodeCov.File.Coverage],
+        coverageDeltaPerFile: [String : CoverageDelta]? = nil,
+        totalCount: Int,
+        totalCountDelta: Int? = nil,
+        overallCoverage: Double,
+        overallCoverageDelta: Double? = nil,
+        coveredProperty: CodeCov.AggregateProperty
+    ) {
+        self.coveragePerFile = coveragePerFile
+        self.coverageDeltaPerFile = coverageDeltaPerFile
+        self.totalCount = totalCount
+        self.totalCountDelta = totalCountDelta
+        self.overallCoverage = overallCoverage
+        self.overallCoverageDelta = overallCoverageDelta
+        self.coveredProperty = coveredProperty
+    }
+    
+}
+
+extension Aggregate {
+    
+    /// Overall coverage -- a number between 0.0 and 100.0
+    public var overallCoveragePercent: Double {
+        overallCoverage.asPercent
+    }
+    
+    /// Overall coverage -- a number between 0.0 and 100.0
+    public var overallCoveragePercentDelta: Double? {
+        guard let overallCoverageDelta else {
+            return nil
+        }
+        return overallCoverageDelta.asPercent
+    }
+
+    /// A String-formatted coverage percentage, out to two decimal places.
+    public var formattedOverallCoveragePercent: String {
+        "\(overallCoverage.asPercentToTwoPlaces)"
+    }
+    
+    /// A String-formatted coverage percentage, out to two decimal places.
+    public var formattedOverallCoveragePercentDelta: String? {
+        guard let overallCoverageDelta else {
+            return nil
+        }
+        return "\(overallCoverageDelta.asPercent.toTwoPlacesWithSign)%"
+    }
+    
+    public var coverageDecreased: Bool {
+        overallCoverageDelta ?? 0 < 0
+    }
+    
+    public var hasDeltas: Bool {
+        coverageDeltaPerFile != nil && totalCountDelta != nil && overallCoverageDelta != nil
+    }
+    
+}
+
+extension [String: CodeCov.File.Coverage] {
+    
+    func delta(_ base: [String: CodeCov.File.Coverage]) -> [String: CoverageDelta] {
+        let baseKeys = Set(base.keys)
+        let currentKeys = Set(keys)
+        
+        let removedFiles = baseKeys.subtracting(currentKeys)
+        
+        let result = removedFiles.reduce([String: CoverageDelta]()) { partialResult, removedFile in
+            var result = partialResult
+            result[removedFile] = .fileRemoved
+            return result
+        }
+        
+        return reduce(result) { partialResult, element in
+            var result = partialResult
+            result[element.key] = element.value.delta(base[element.key])
+            return result
+        }
+    }
+    
+}
+
+extension CodeCov.File.Coverage {
+    
+    func delta(_ base: CodeCov.File.Coverage?) -> CoverageDelta {
+        guard let base else {
+            return .fileAdded(self)
+        }
+        
+        return .delta(CodeCov.File.Coverage(
+            count: count - base.count,
+            covered: covered - base.covered,
+            percent: percent - base.percent
+        ))
+    }
+    
+}
+
+public extension Double {
+    
+    var sign: String {
+        self > 0 ? "+" : ""
+    }
+    
+    var asPercent: Double {
+        self * 100
+    }
+    
+    var asPercentToTwoPlaces: String {
+        "\(asPercent.toTwoPlaces)%"
+    }
+    
+    var toTwoPlaces: String {
+        String(format: "%.2f", self)
+    }
+    
+    var toTwoPlacesWithSign: String {
+        "\(sign)\(toTwoPlaces)"
+    }
+    
 }
 
 extension Regex {
     
-    init?(string: String?) throws {
-        guard let string else {
+    init?(optionalString: String?) throws {
+        guard let string = optionalString else {
             return nil
         }
         try self.init(string: string)

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -27,6 +27,7 @@ public func isExcludedPath(_ path: String, regex: Regex?) -> Bool {
 }
 
 public enum CoverageDelta: Codable, Equatable {
+    case noChange
     case fileAdded(newCoverage: CodeCov.File.Coverage)
     case fileRemoved
     case delta(coverageChange: CodeCov.File.Coverage)
@@ -222,10 +223,18 @@ extension CodeCov.File.Coverage {
             return .fileAdded(newCoverage: self)
         }
         
+        let countChange = count - base.count
+        let coveredChange = covered - base.covered
+        let percentChange = percent - base.percent
+        
+        if countChange == 0 && coveredChange == 0 && percentChange == 0 {
+            return .noChange
+        }
+        
         return .delta(coverageChange: CodeCov.File.Coverage(
             count: count - base.count,
             covered: covered - base.covered,
-            percent: percent - base.percent
+            percent: percentChange
         ))
     }
     

--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -27,9 +27,9 @@ public func isExcludedPath(_ path: String, regex: Regex?) -> Bool {
 }
 
 public enum CoverageDelta: Codable, Equatable {
-    case fileAdded(CodeCov.File.Coverage)
+    case fileAdded(newCoverage: CodeCov.File.Coverage)
     case fileRemoved
-    case delta(CodeCov.File.Coverage)
+    case delta(coverageChange: CodeCov.File.Coverage)
 }
 
 public enum AggregateError: Error, Equatable {
@@ -219,10 +219,10 @@ extension CodeCov.File.Coverage {
     
     func delta(_ base: CodeCov.File.Coverage?) -> CoverageDelta {
         guard let base else {
-            return .fileAdded(self)
+            return .fileAdded(newCoverage: self)
         }
         
-        return .delta(CodeCov.File.Coverage(
+        return .delta(coverageChange: CodeCov.File.Coverage(
             count: count - base.count,
             covered: covered - base.covered,
             percent: percent - base.percent

--- a/Sources/SwiftTestCodecovLib/CodeCov.swift
+++ b/Sources/SwiftTestCodecovLib/CodeCov.swift
@@ -10,6 +10,7 @@ import Foundation
 /// A Decodable representation of the JSON that
 /// `swift test --enable-code-coverage` outputs.
 public struct CodeCov: Decodable {
+    
     public let version: String
     public let type: String
     public let data: [Data]
@@ -49,17 +50,29 @@ public struct CodeCov: Decodable {
             }
         }
 
-        public struct Coverage: Codable {
+        public struct Coverage: Codable, Equatable {
             public let count: Int
             public let covered: Int
             public let percent: Double
         }
     }
 
-    public enum AggregateProperty: String, RawRepresentable, CaseIterable {
+    public enum AggregateProperty: String, RawRepresentable, CaseIterable, Codable {
         case lines
         case functions
         case instantiations
+    }
+}
+
+extension CodeCov.File.Coverage {
+    /// Internal constructor for use in Unit Tests
+    internal init(
+        count: Int = 0,
+        covered: Int = 0
+    ) {
+        self.count = count
+        self.covered = covered
+        self.percent = Double(covered) / Double(count) * 100.0
     }
 }
 

--- a/Sources/SwiftTestCodecovLogic/AggregateHelpers.swift
+++ b/Sources/SwiftTestCodecovLogic/AggregateHelpers.swift
@@ -1,0 +1,29 @@
+//
+//  AggregateHelpers.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import Foundation
+import SwiftTestCodecovLib
+
+public extension Aggregate {
+    
+    var minimalDisplay: String {
+        var result = formattedOverallCoveragePercent
+        if let formattedOverallCoveragePercentDelta = formattedOverallCoveragePercentDelta {
+            result += " (\(formattedOverallCoveragePercentDelta))"
+        }
+        
+        return result
+    }
+    
+    var numericDisplay: Double {
+        if let delta = overallCoveragePercentDelta {
+            return delta
+        }
+        return overallCoveragePercent
+    }
+    
+}

--- a/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
+++ b/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
@@ -1,0 +1,111 @@
+//
+//  CoverageTableRow.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import Foundation
+import SwiftTestCodecovLib
+
+public struct CoverageTableRow {
+    
+    public let dependency: Bool?
+    public let filename: String
+    public let coverage: Double
+    public let delta: CoverageDelta?
+    
+    public init(dependency: Bool? = nil, filename: String, coverage: Double, delta: CoverageDelta? = nil) {
+        self.dependency = dependency
+        self.filename = filename
+        self.coverage = coverage
+        self.delta = delta
+    }
+}
+
+extension CoverageTableRow: Equatable {}
+
+public extension CoverageTableRow {
+    
+    static var blank = CoverageTableRow(dependency: nil, filename: "", coverage: -1, delta: nil)
+    static var divider = CoverageTableRow(dependency: nil, filename: "=-=-=-=-=-=-=-=-=", coverage: -1, delta: nil)
+    
+    var coverageDeltaString: String {
+        guard let delta else {
+            return ""
+        }
+        switch delta {
+        case .fileRemoved:
+            return "X"
+        case .fileAdded(let coverage):
+            return "\(coverage.percent.toTwoPlaces)%"
+        case .delta(let coverage):
+            guard coverage.percent != 0 else {
+                return "-"
+            }
+            return "\(coverage.percent.toTwoPlacesWithSign)%"
+        }
+    }
+    
+    var coverageString: String {
+        coverage >= 0 ? "\(coverage.toTwoPlaces)%" : ""
+    }
+    
+    var isDependencyString: String {
+        (dependency ?? false)  ? "✓" : ""
+    }
+    
+}
+
+public extension [CoverageTableRow] {
+    
+    func splitOutTests() -> [CoverageTableRow] {
+        
+        var sourceCoverages = [CoverageTableRow]()
+        var testCoverages = [CoverageTableRow]()
+        for fileCoverage in self {
+            if fileCoverage.filename.contains("Tests") {
+                testCoverages.append(fileCoverage)
+            } else {
+                sourceCoverages.append(fileCoverage)
+            }
+        }
+        
+        return sourceCoverages + [CoverageTableRow.blank, CoverageTableRow.divider, CoverageTableRow.blank] + testCoverages
+        
+    }
+    
+}
+
+public extension Aggregate {
+    
+    func asTableData(includeDependencies: Bool, projectName: String?, sortOrder: SortOrder) -> [CoverageTableRow] {
+        
+        let coverage = coveragePerFile
+        let deltas = coverageDeltaPerFile
+        let fileCoverages: [CoverageTableRow] = coverage.map { kvp in
+            let fileDelta = deltas?[kvp.key]
+            return CoverageTableRow(
+                dependency: includeDependencies ? isDependencyPath(kvp.key, projectName: projectName) : nil,
+                filename: URL(fileURLWithPath: kvp.key).lastPathComponent,
+                coverage: kvp.value.percent,
+                delta: hasDeltas ? fileDelta : nil
+            )
+        }
+
+        let sortedCoverage : [CoverageTableRow]
+        switch sortOrder {
+        case .filename:
+            // we always sort by filename above, even if we subsequently sort by another field.
+            sortedCoverage = fileCoverages.sorted { $0.filename < $1.filename }
+        case .coverageAsc:
+            sortedCoverage = fileCoverages.sorted { $0.coverage < $1.coverage }
+        case .coverageDesc:
+            sortedCoverage = fileCoverages.sorted { $0.coverage > $1.coverage }
+        }
+        
+        return sortedCoverage
+        
+    }
+    
+}

--- a/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
+++ b/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
@@ -35,6 +35,8 @@ public extension CoverageTableRow {
             return ""
         }
         switch delta {
+        case .noChange:
+            return "-"
         case .fileRemoved:
             return "(Removed)"
         case .fileAdded(let coverage):

--- a/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
+++ b/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
@@ -98,7 +98,7 @@ public extension Aggregate {
                     dependency: includeDependencies ? isDependencyPath(kvp.key, projectName: projectName) : nil,
                     filename: URL(fileURLWithPath: kvp.key).lastPathComponent,
                     coverage: -1,
-                    delta: hasDeltas ? kvp.value : nil
+                    delta: kvp.value
                 )
             })
         }

--- a/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
+++ b/Sources/SwiftTestCodecovLogic/CoverageTableRow.swift
@@ -36,7 +36,7 @@ public extension CoverageTableRow {
         }
         switch delta {
         case .fileRemoved:
-            return "X"
+            return "(Removed)"
         case .fileAdded(let coverage):
             return "\(coverage.percent.toTwoPlaces)%"
         case .delta(let coverage):
@@ -83,7 +83,7 @@ public extension Aggregate {
         
         let coverage = coveragePerFile
         let deltas = coverageDeltaPerFile
-        let fileCoverages: [CoverageTableRow] = coverage.map { kvp in
+        var fileCoverages: [CoverageTableRow] = coverage.map { kvp in
             let fileDelta = deltas?[kvp.key]
             return CoverageTableRow(
                 dependency: includeDependencies ? isDependencyPath(kvp.key, projectName: projectName) : nil,
@@ -91,6 +91,16 @@ public extension Aggregate {
                 coverage: kvp.value.percent,
                 delta: hasDeltas ? fileDelta : nil
             )
+        }
+        if let deltas {
+            fileCoverages.append(contentsOf: deltas.filter { $0.value == .fileRemoved }.map { kvp in
+                CoverageTableRow(
+                    dependency: includeDependencies ? isDependencyPath(kvp.key, projectName: projectName) : nil,
+                    filename: URL(fileURLWithPath: kvp.key).lastPathComponent,
+                    coverage: -1,
+                    delta: hasDeltas ? kvp.value : nil
+                )
+            })
         }
 
         let sortedCoverage : [CoverageTableRow]

--- a/Sources/SwiftTestCodecovLogic/SortOrder.swift
+++ b/Sources/SwiftTestCodecovLogic/SortOrder.swift
@@ -1,0 +1,15 @@
+//
+//  SortOrder.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import Foundation
+
+/// How to sort the coverage table results (if `PrintFormat` is `.table`).
+public enum SortOrder: String, CaseIterable {
+    case filename
+    case coverageAsc = "+cov"
+    case coverageDesc = "-cov"
+}

--- a/Sources/SwiftTestCodecovLogic/TextTableHelpers.swift
+++ b/Sources/SwiftTestCodecovLogic/TextTableHelpers.swift
@@ -1,0 +1,17 @@
+//
+//  TextTableHelpers.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import Foundation
+import TextTable
+
+public extension Column {
+    
+    func includeIf(_ shouldShow: Bool) -> Column? {
+        shouldShow ? self : nil
+    }
+    
+}

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -203,7 +203,7 @@ struct StatsCommand: ParsableCommand {
         }
         
 
-        let passedMinimumCoverage = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
+        let passedMinimumCoverage = aggregateCoverage.overallCoveragePercent >= Double(minimumCov)
 
         if !passedMinimumCoverage && printFormat != .json && explainFailure {
             // we don't print the error message out for the minimal or JSON formats.

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -201,7 +201,7 @@ struct StatsCommand: ParsableCommand {
             print("Double check that you are either running this tool from the root of your target project or else you've specified a project-name that has the exact name of the root folder of your target project -- otherwise, all files may be filtered out as belonging to other projects (dependencies).")
         }
         
-        let passedMinimumCoverage = aggregateCoverage.overallCoveragePercent >= Double(minimumCov)
+        let passedMinimumCoverage = aggregateCoverage.overallCoveragePercent >= Double(minimumCoverage)
 
         if !passedMinimumCoverage && printFormat != .json && explainFailure {
             // we don't print the error message out for the JSON format.

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -206,7 +206,7 @@ struct StatsCommand: ParsableCommand {
         let passedMinimumCoverage = aggregateCoverage.overallCoveragePercent >= Double(minimumCov)
 
         if !passedMinimumCoverage && printFormat != .json && explainFailure {
-            // we don't print the error message out for the minimal or JSON formats.
+            // we don't print the error message out for the JSON format.
             print("")
             print("The overall coverage did not meet the minimum threshold of \(minimumCov)%")
         }

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -213,8 +213,8 @@ struct StatsCommand: ParsableCommand {
         
         let passedNonNegativeCoverageDelta = !failOnNegativeDelta || !aggregateCoverage.coverageDecreased
         
-        if !passedNonNegativeCoverageDelta && explainFailure {
-            // we don't print the error message out for the minimal or JSON formats.
+        if !passedNonNegativeCoverageDelta && printFormat != .json && explainFailure {
+            // we don't print the error message out for the JSON format.
             print("")
             let filePath: String
             if let baseJSONFile {

--- a/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
+++ b/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
@@ -281,7 +281,7 @@ final class String_CodeCovFileCoverage_Dictionary_ExtensionTests: XCTestCase {
         let delta = cut.delta(base)
         
         XCTAssertEqual(delta, [
-            "Filename.swift": .fileAdded(
+            "Filename.swift": .fileAdded(newCoverage:
                 CodeCov.File.Coverage(
                     count: 10,
                     covered: 9,
@@ -311,7 +311,7 @@ final class String_CodeCovFileCoverage_Dictionary_ExtensionTests: XCTestCase {
         
     }
     
-    func testEqualDelta() throws {
+    func testNoChangeDelta() throws {
         
         let cut = [
             "Filename.swift": CodeCov.File.Coverage(
@@ -331,11 +331,36 @@ final class String_CodeCovFileCoverage_Dictionary_ExtensionTests: XCTestCase {
         let delta = cut.delta(base)
         
         XCTAssertEqual(delta, [
-            "Filename.swift": .delta(
+            "Filename.swift": .noChange
+        ])
+        
+    }
+    
+    func testNoPercentageChangeDelta() throws {
+        
+        let cut = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 100,
+                covered: 90,
+                percent: 0.9
+            )
+        ]
+        let base = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertEqual(delta, [
+            "Filename.swift": .delta(coverageChange:
                 CodeCov.File.Coverage(
-                    count: 0,
-                    covered: 0,
-                    percent: 0
+                    count: 90,
+                    covered: 81,
+                    percent: 0.0
                 )
             )
         ])
@@ -372,20 +397,14 @@ final class String_CodeCovFileCoverage_Dictionary_ExtensionTests: XCTestCase {
         let delta = cut.delta(base)
         
         XCTAssertEqual(delta, [
-            "FilenameAdded.swift": .fileAdded(
+            "FilenameAdded.swift": .fileAdded(newCoverage:
                 CodeCov.File.Coverage(
                     count: 100,
                     covered: 90,
                     percent: 0.9
                 )
             ),
-            "Filename.swift": .delta(
-                CodeCov.File.Coverage(
-                    count: 0,
-                    covered: 0,
-                    percent: 0
-                )
-            ),
+            "Filename.swift": .noChange,
             "FilenameRemoved.swift": .fileRemoved,
         ])
         
@@ -405,7 +424,7 @@ final class CodeCovFileCoverageExtensionTests: XCTestCase {
         
         let result = cut.delta(nil)
         
-        XCTAssertEqual(result, .fileAdded(
+        XCTAssertEqual(result, .fileAdded(newCoverage:
             CodeCov.File.Coverage(
                 count: 100,
                 covered: 75,
@@ -431,13 +450,7 @@ final class CodeCovFileCoverageExtensionTests: XCTestCase {
         
         let result = cut.delta(base)
         
-        XCTAssertEqual(result, .delta(
-            CodeCov.File.Coverage(
-                count: 0,
-                covered: 0,
-                percent: 0
-            )
-        ))
+        XCTAssertEqual(result, .noChange)
         
     }
     

--- a/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
+++ b/Tests/SwiftTestCodecovLibTests/AggregateTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import Regex
 @testable import SwiftTestCodecovLib
 
-final class AggregateTests: XCTestCase {
+final class AggregateHelperFunctionTests: XCTestCase {
 
     func testIsExcludedPath() throws {
         
@@ -21,5 +21,547 @@ final class AggregateTests: XCTestCase {
         XCTAssertTrue(isExcludedPath(".build/Sources/Project/MyView.swift", regex: helpExampleRegex))
         XCTAssertTrue(isExcludedPath(".build/Sources/Project/MyMock.swift", regex: helpExampleRegex))
     }
+    
+    func testIsExcludedPath_NoRegex() throws {
+        
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/MyModel.swift", regex: nil))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/View/ViewName.swift", regex: nil))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/Mock/MockName.swift", regex: nil))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/MyView.swift", regex: nil))
+        XCTAssertFalse(isExcludedPath(".build/Sources/Project/MyMock.swift", regex: nil))
+    }
 
+}
+
+final class AggregateTests: XCTestCase {
+    
+    func testInit_BaseWithDifferentCoveredProperty() throws {
+        
+        let base = try Aggregate(
+            coverage: CodeCov(version: "", type: "", data: []),
+            property: .functions,
+            includeDependencies: false,
+            includeTests: false,
+            excludeRegexString: nil,
+            fromBase: nil
+        )
+        
+        do {
+            _ = try Aggregate(
+                coverage: CodeCov(version: "", type: "", data: []),
+                property: .lines,
+                includeDependencies: false,
+                includeTests: false,
+                excludeRegexString: nil,
+                fromBase: base
+            )
+            XCTFail("Aggregate contructor should have thrown")
+        } catch {
+            if let error = error as? AggregateError {
+                XCTAssertEqual(error, .invalidBaseAggregate("functions"))
+            } else {
+                XCTFail("Invalid AggregateError type")
+            }
+        }
+        
+    }
+    
+    func testOverallCoveragePercent() throws {
+        
+        let cut = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertEqual(cut.overallCoveragePercent, 95, accuracy: 0.01)
+        
+    }
+    
+    func testOverallCoveragePercentDelta() throws {
+        
+        let cut = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: 0.10,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertEqual(cut.overallCoveragePercentDelta!, 10, accuracy: 0.01)
+        
+    }
+    
+    func testOverallCoveragePercentDelta_NoBase() throws {
+        
+        let cut = try! Aggregate(
+            coverage: CodeCov(version: "", type: "", data: []),
+            property: .lines,
+            includeDependencies: false,
+            includeTests: false,
+            excludeRegexString: nil,
+            fromBase: nil
+        )
+        
+        XCTAssertNil(cut.overallCoveragePercentDelta)
+        
+    }
+    
+    func testFormattedOverallCoveragePercent() throws {
+        
+        let cut = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: 0.10,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertEqual(cut.formattedOverallCoveragePercent, "95.00%")
+        
+    }
+    
+    func testFormattedOverallCoveragePercentDelta() throws {
+        
+        let cut = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: 0.10,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertEqual(cut.formattedOverallCoveragePercentDelta!, "+10.00%")
+        
+    }
+    
+    func testFormattedOverallCoveragePercentDelta_NoBase() throws {
+        
+        let cut = try! Aggregate(
+            coverage: CodeCov(version: "", type: "", data: []),
+            property: .lines,
+            includeDependencies: false,
+            includeTests: false,
+            excludeRegexString: nil,
+            fromBase: nil
+        )
+        
+        XCTAssertNil(cut.formattedOverallCoveragePercentDelta)
+        
+    }
+    
+    func testCoverageDecreased() throws {
+        
+        let increase = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: 0.10,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertFalse(increase.coverageDecreased)
+        
+        let decrease = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: -0.10,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertTrue(decrease.coverageDecreased)
+        
+        let noChange = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            overallCoverageDelta: 0,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertFalse(noChange.coverageDecreased)
+        
+    }
+    
+    func testCoverageDecreased_NoBase() throws {
+        
+        let noBase = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertFalse(noBase.coverageDecreased)
+        
+    }
+    
+    func testHasDeltas() throws {
+        
+        XCTAssertFalse(Aggregate(
+            coveragePerFile: [:],
+            totalCount: 10,
+            totalCountDelta: 1,
+            overallCoverage: 1.0,
+            overallCoverageDelta: 0.1,
+            coveredProperty: .functions
+        ).hasDeltas)
+        
+        XCTAssertFalse(Aggregate(
+            coveragePerFile: [:],
+            coverageDeltaPerFile: [:],
+            totalCount: 10,
+            overallCoverage: 1.0,
+            overallCoverageDelta: 0.1,
+            coveredProperty: .functions
+        ).hasDeltas)
+        
+        XCTAssertFalse(Aggregate(
+            coveragePerFile: [:],
+            coverageDeltaPerFile: [:],
+            totalCount: 10,
+            totalCountDelta: 1,
+            overallCoverage: 1.0,
+            coveredProperty: .functions
+        ).hasDeltas)
+        
+        XCTAssertTrue(Aggregate(
+            coveragePerFile: [:],
+            coverageDeltaPerFile: [:],
+            totalCount: 10,
+            totalCountDelta: 1,
+            overallCoverage: 1.0,
+            overallCoverageDelta: 0.1,
+            coveredProperty: .functions
+        ).hasDeltas)
+        
+    }
+    
+    func testHasDeltas_NoBase() throws {
+        
+        let noBase = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 1000,
+            overallCoverage: 0.95,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertFalse(noBase.hasDeltas)
+        
+    }
+    
+}
+
+final class String_CodeCovFileCoverage_Dictionary_ExtensionTests: XCTestCase {
+    
+    func testEmptyDelta() throws {
+        
+        let cut = [String: CodeCov.File.Coverage]()
+        let base = [String: CodeCov.File.Coverage]()
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertTrue(delta.isEmpty)
+        
+    }
+    
+    func testAddDelta() throws {
+        
+        let cut = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        let base = [String: CodeCov.File.Coverage]()
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertEqual(delta, [
+            "Filename.swift": .fileAdded(
+                CodeCov.File.Coverage(
+                    count: 10,
+                    covered: 9,
+                    percent: 0.9
+                )
+            )
+        ])
+        
+    }
+    
+    func testRemoveDelta() throws {
+        
+        let cut = [String: CodeCov.File.Coverage]()
+        let base = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertEqual(delta, [
+            "Filename.swift": .fileRemoved
+        ])
+        
+    }
+    
+    func testEqualDelta() throws {
+        
+        let cut = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        let base = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertEqual(delta, [
+            "Filename.swift": .delta(
+                CodeCov.File.Coverage(
+                    count: 0,
+                    covered: 0,
+                    percent: 0
+                )
+            )
+        ])
+        
+    }
+    
+    func testAllDelta() throws {
+        
+        let cut = [
+            "FilenameAdded.swift": CodeCov.File.Coverage(
+                count: 100,
+                covered: 90,
+                percent: 0.9
+            ),
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        let base = [
+            "Filename.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            ),
+            "FilenameRemoved.swift": CodeCov.File.Coverage(
+                count: 10,
+                covered: 9,
+                percent: 0.9
+            )
+        ]
+        
+        let delta = cut.delta(base)
+        
+        XCTAssertEqual(delta, [
+            "FilenameAdded.swift": .fileAdded(
+                CodeCov.File.Coverage(
+                    count: 100,
+                    covered: 90,
+                    percent: 0.9
+                )
+            ),
+            "Filename.swift": .delta(
+                CodeCov.File.Coverage(
+                    count: 0,
+                    covered: 0,
+                    percent: 0
+                )
+            ),
+            "FilenameRemoved.swift": .fileRemoved,
+        ])
+        
+    }
+    
+}
+
+final class CodeCovFileCoverageExtensionTests: XCTestCase {
+    
+    func testDelta_Added() throws {
+        
+        let cut = CodeCov.File.Coverage(
+            count: 100,
+            covered: 75,
+            percent: 0.75
+        )
+        
+        let result = cut.delta(nil)
+        
+        XCTAssertEqual(result, .fileAdded(
+            CodeCov.File.Coverage(
+                count: 100,
+                covered: 75,
+                percent: 0.75
+            )
+        ))
+        
+    }
+    
+    func testDelta_Equal() throws {
+        
+        let cut = CodeCov.File.Coverage(
+            count: 100,
+            covered: 75,
+            percent: 0.75
+        )
+        
+        let base = CodeCov.File.Coverage(
+            count: 100,
+            covered: 75,
+            percent: 0.75
+        )
+        
+        let result = cut.delta(base)
+        
+        XCTAssertEqual(result, .delta(
+            CodeCov.File.Coverage(
+                count: 0,
+                covered: 0,
+                percent: 0
+            )
+        ))
+        
+    }
+    
+    func testDelta_Lower() throws {
+        
+        let cut = CodeCov.File.Coverage(
+            count: 100,
+            covered: 75,
+            percent: 0.75
+        )
+        
+        let base = CodeCov.File.Coverage(
+            count: 110,
+            covered: 109,
+            percent: 0.99
+        )
+        
+        let result = cut.delta(base)
+        
+        switch result {
+        case .delta(let coverageDelta):
+            XCTAssertEqual(coverageDelta.count, -10)
+            XCTAssertEqual(coverageDelta.covered, -34)
+            XCTAssertEqual(coverageDelta.percent, -0.24, accuracy: 0.01)
+        default:
+            XCTFail("Incorrect Result")
+        }
+        
+    }
+    
+    func testDelta_Higher() throws {
+        
+        let cut = CodeCov.File.Coverage(
+            count: 110,
+            covered: 109,
+            percent: 0.99
+        )
+        
+        let base = CodeCov.File.Coverage(
+            count: 100,
+            covered: 75,
+            percent: 0.75
+        )
+        
+        let result = cut.delta(base)
+        
+        switch result {
+        case .delta(let coverageDelta):
+            XCTAssertEqual(coverageDelta.count, 10)
+            XCTAssertEqual(coverageDelta.covered, 34)
+            XCTAssertEqual(coverageDelta.percent, 0.24, accuracy: 0.01)
+        default:
+            XCTFail("Incorrect Result")
+        }
+        
+    }
+    
+}
+
+final class DoublePercentExtensionTests: XCTestCase {
+
+    func testSign() throws {
+        
+        XCTAssertEqual((1.0).sign, "+")
+        XCTAssertEqual((0.0).sign, "")
+        XCTAssertEqual((-1.0).sign, "") // Negative is provided natively by double string formatting
+        
+    }
+    
+    func testAsPercent() throws {
+        
+        let cut = 0.25
+        
+        XCTAssertEqual(cut.asPercent, 25, accuracy: 0.01)
+        
+    }
+    
+    func testAsPercentToTwoPlaces() throws {
+        
+        let cut = 0.25
+        
+        XCTAssertEqual(cut.asPercentToTwoPlaces, "25.00%")
+        
+    }
+    
+    func testToTwoPlaces() throws {
+        
+        let cut = 0.25
+        
+        XCTAssertEqual(cut.toTwoPlaces, "0.25")
+        
+    }
+    
+    func testToTwoPlacesWithSign() throws {
+        
+        XCTAssertEqual((0.25).toTwoPlacesWithSign, "+0.25")
+        XCTAssertEqual((0.0).toTwoPlacesWithSign, "0.00")
+        XCTAssertEqual((-0.25).toTwoPlacesWithSign, "-0.25")
+        
+    }
+    
+}
+
+final class RegexExtensionTests: XCTestCase {
+    
+    func testInit() throws {
+        let cut = try Regex(optionalString: "Test\\.swift")
+        XCTAssertNotNil(cut)
+    }
+    
+    func testInit_NilString() throws {
+        let cut = try Regex(optionalString: nil)
+        XCTAssertNil(cut)
+    }
+    
+    func testInit_InvalidRegex() throws {
+        var didThrow = false
+        do {
+            _ = try Regex(optionalString: "++")
+            XCTFail("Regex should throw...")
+        } catch {
+            didThrow = true
+        }
+        XCTAssertTrue(didThrow)
+    }
+    
 }

--- a/Tests/SwiftTestCodecovLogicTests/AggregateHelpersTests.swift
+++ b/Tests/SwiftTestCodecovLogicTests/AggregateHelpersTests.swift
@@ -1,0 +1,95 @@
+//
+//  AggregateHelpersTests.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import XCTest
+@testable import SwiftTestCodecovLib
+@testable import SwiftTestCodecovLogic
+
+final class AggregateHelpersTests: XCTestCase {
+    
+    func testMinimalDisplay() throws {
+        
+        let aggregate = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: 0.25,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithNegativeDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: -0.25,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithNoDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: 0.0,
+            coveredProperty: .lines
+        )
+
+        
+        XCTAssertEqual(aggregate.minimalDisplay, "50.00%")
+        XCTAssertEqual(aggregateWithDelta.minimalDisplay, "50.00% (+25.00%)")
+        XCTAssertEqual(aggregateWithNegativeDelta.minimalDisplay, "50.00% (-25.00%)")
+        XCTAssertEqual(aggregateWithNoDelta.minimalDisplay, "50.00% (0.00%)")
+        
+    }
+    
+    func testNumericDisplay() throws {
+        
+        let aggregate = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: 0.25,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithNegativeDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: -0.25,
+            coveredProperty: .lines
+        )
+        
+        let aggregateWithNoDelta = Aggregate(
+            coveragePerFile: [:],
+            totalCount: 100,
+            overallCoverage: 0.50,
+            overallCoverageDelta: 0.0,
+            coveredProperty: .lines
+        )
+        
+        XCTAssertEqual(aggregate.numericDisplay, 50.0)
+        XCTAssertEqual(aggregateWithDelta.numericDisplay, 25.0)
+        XCTAssertEqual(aggregateWithNegativeDelta.numericDisplay, -25.0)
+        XCTAssertEqual(aggregateWithNoDelta.numericDisplay, 0.0)
+        
+    }
+
+}

--- a/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
+++ b/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
@@ -20,25 +20,25 @@ final class CoverageTableRowTests: XCTestCase {
 
         XCTAssertEqual(
             CoverageTableRow.testRow(delta: .fileRemoved).coverageDeltaString,
-            "X"
+            "(Removed)"
         )
 
         let exampleCoverageDelta = CodeCov.File.Coverage(count: 10, covered: 9)
 
         XCTAssertEqual(
-            CoverageTableRow.testRow(delta: .fileAdded(exampleCoverageDelta)).coverageDeltaString,
+            CoverageTableRow.testRow(delta: .fileAdded(newCoverage: exampleCoverageDelta)).coverageDeltaString,
             "90.00%"
         )
 
         XCTAssertEqual(
-            CoverageTableRow.testRow(delta: .delta(exampleCoverageDelta)).coverageDeltaString,
+            CoverageTableRow.testRow(delta: .delta(coverageChange: exampleCoverageDelta)).coverageDeltaString,
             "+90.00%"
         )
         
         let exampleCoverageDeltaNoChange = CodeCov.File.Coverage(count: 10, covered: 0)
         
         XCTAssertEqual(
-            CoverageTableRow.testRow(delta: .delta(exampleCoverageDeltaNoChange)).coverageDeltaString,
+            CoverageTableRow.testRow(delta: .delta(coverageChange: exampleCoverageDeltaNoChange)).coverageDeltaString,
             "-"
         )
         
@@ -141,6 +141,7 @@ final class AggregateExtensionTests: XCTestCase {
             "C/C.swift": fileC100Delta,
             "B/B.swift": fileB25Delta,
             "A/A.swift": fileA50Delta,
+            "D/D.swift": CoverageDelta.fileRemoved
         ],
         totalCount: 7,
         totalCountDelta: 0,
@@ -217,6 +218,7 @@ final class AggregateExtensionTests: XCTestCase {
             .testRow(filename: "A.swift", coverage: 50, delta: Self.fileA50Delta),
             .testRow(filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
             .testRow(filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
+            .testRow(filename: "D.swift", coverage: -1, delta: .fileRemoved)
         ])
         
     }
@@ -249,6 +251,7 @@ final class AggregateExtensionTests: XCTestCase {
             .testRow(dependency: true, filename: "A.swift", coverage: 50, delta: Self.fileA50Delta),
             .testRow(dependency: false, filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
             .testRow(dependency: true, filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
+            .testRow(dependency: true, filename: "D.swift", coverage: -1, delta: .fileRemoved),
         ])
         
     }

--- a/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
+++ b/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
@@ -22,6 +22,11 @@ final class CoverageTableRowTests: XCTestCase {
             CoverageTableRow.testRow(delta: .fileRemoved).coverageDeltaString,
             "(Removed)"
         )
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: .noChange).coverageDeltaString,
+            "-"
+        )
 
         let exampleCoverageDelta = CodeCov.File.Coverage(count: 10, covered: 9)
 
@@ -136,12 +141,14 @@ final class AggregateExtensionTests: XCTestCase {
             "C/C.swift": fileC100,
             "B/B.swift": fileB25,
             "A/A.swift": fileA50,
+            "E/E.swift": fileE75
         ],
         coverageDeltaPerFile: [
             "C/C.swift": fileC100Delta,
             "B/B.swift": fileB25Delta,
             "A/A.swift": fileA50Delta,
-            "D/D.swift": CoverageDelta.fileRemoved
+            "D/D.swift": CoverageDelta.fileRemoved,
+            "E/E.swift": CoverageDelta.noChange
         ],
         totalCount: 7,
         totalCountDelta: 0,
@@ -153,6 +160,7 @@ final class AggregateExtensionTests: XCTestCase {
     static let fileA50 = CodeCov.File.Coverage(count: 2, covered: 1)
     static let fileB25 = CodeCov.File.Coverage(count: 4, covered: 1)
     static let fileC100 = CodeCov.File.Coverage(count: 1, covered: 1)
+    static let fileE75 = CodeCov.File.Coverage(count: 4, covered: 3)
     
     static let fileA50Delta = CodeCov.File.Coverage(count: 2, covered: 1).delta(CodeCov.File.Coverage(count: 2, covered: 0))
     static let fileB25Delta = CodeCov.File.Coverage(count: 4, covered: 1).delta(CodeCov.File.Coverage(count: 4, covered: 0))
@@ -218,7 +226,8 @@ final class AggregateExtensionTests: XCTestCase {
             .testRow(filename: "A.swift", coverage: 50, delta: Self.fileA50Delta),
             .testRow(filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
             .testRow(filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
-            .testRow(filename: "D.swift", coverage: -1, delta: .fileRemoved)
+            .testRow(filename: "D.swift", coverage: -1, delta: .fileRemoved),
+            .testRow(filename: "E.swift", coverage: 75, delta: .noChange),
         ])
         
     }
@@ -252,6 +261,7 @@ final class AggregateExtensionTests: XCTestCase {
             .testRow(dependency: false, filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
             .testRow(dependency: true, filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
             .testRow(dependency: true, filename: "D.swift", coverage: -1, delta: .fileRemoved),
+            .testRow(dependency: true, filename: "E.swift", coverage: 75, delta: .noChange),
         ])
         
     }

--- a/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
+++ b/Tests/SwiftTestCodecovLogicTests/CoverageTableRowTests.swift
@@ -1,0 +1,256 @@
+//
+//  CoverageTableRowTests.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import XCTest
+@testable import SwiftTestCodecovLib
+@testable import SwiftTestCodecovLogic
+
+final class CoverageTableRowTests: XCTestCase {
+
+    func testCoverageDeltaString() throws {
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: nil).coverageDeltaString,
+            ""
+        )
+
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: .fileRemoved).coverageDeltaString,
+            "X"
+        )
+
+        let exampleCoverageDelta = CodeCov.File.Coverage(count: 10, covered: 9)
+
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: .fileAdded(exampleCoverageDelta)).coverageDeltaString,
+            "90.00%"
+        )
+
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: .delta(exampleCoverageDelta)).coverageDeltaString,
+            "+90.00%"
+        )
+        
+        let exampleCoverageDeltaNoChange = CodeCov.File.Coverage(count: 10, covered: 0)
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(delta: .delta(exampleCoverageDeltaNoChange)).coverageDeltaString,
+            "-"
+        )
+        
+    }
+    
+    func testCoverageString() throws {
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(coverage: -1).coverageString,
+            ""
+        )
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(coverage: 0).coverageString,
+            "0.00%"
+        )
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(coverage: 90).coverageString,
+            "90.00%"
+        )
+    }
+    
+    func testIsDependencyString() throws {
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(dependency: nil).isDependencyString,
+            ""
+        )
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(dependency: false).isDependencyString,
+            ""
+        )
+        
+        XCTAssertEqual(
+            CoverageTableRow.testRow(dependency: true).isDependencyString,
+            "✓"
+        )
+        
+    }
+    
+    func testSplitOutTests() throws {
+        
+        let businessLogic = CoverageTableRow.testRow(filename: "BusinessLogic.swift")
+        let businessLogicTests = CoverageTableRow.testRow(filename: "BusinessLogicTests.swift")
+        let testHelper = CoverageTableRow.testRow(filename: "Tests/MockObject.swift")
+        
+        let cut: [CoverageTableRow] = [
+            businessLogic,
+            businessLogicTests,
+            testHelper
+        ]
+        
+        XCTAssertEqual(cut.splitOutTests(), [
+            businessLogic,
+            CoverageTableRow.blank,
+            CoverageTableRow.divider,
+            CoverageTableRow.blank,
+            businessLogicTests,
+            testHelper
+        ])
+        
+    }
+    
+    func testSplitOutTests_Empty() throws {
+        
+        let cut: [CoverageTableRow] = []
+        
+        XCTAssertEqual(cut.splitOutTests(), [
+            CoverageTableRow.blank,
+            CoverageTableRow.divider,
+            CoverageTableRow.blank
+        ])
+        
+    }
+
+}
+
+final class AggregateExtensionTests: XCTestCase {
+    
+    static let testAggregate = Aggregate(
+        coveragePerFile: [
+            "C/C.swift": fileC100,
+            "B/B.swift": fileB25,
+            "A/A.swift": fileA50,
+        ],
+        totalCount: 7,
+        overallCoverage: 3/7,
+        coveredProperty: .lines
+    )
+    
+    static let testAggregateWithDeltas = Aggregate(
+        coveragePerFile: [
+            "C/C.swift": fileC100,
+            "B/B.swift": fileB25,
+            "A/A.swift": fileA50,
+        ],
+        coverageDeltaPerFile: [
+            "C/C.swift": fileC100Delta,
+            "B/B.swift": fileB25Delta,
+            "A/A.swift": fileA50Delta,
+        ],
+        totalCount: 7,
+        totalCountDelta: 0,
+        overallCoverage: 3/7,
+        overallCoverageDelta: 3/7,
+        coveredProperty: .lines
+    )
+    
+    static let fileA50 = CodeCov.File.Coverage(count: 2, covered: 1)
+    static let fileB25 = CodeCov.File.Coverage(count: 4, covered: 1)
+    static let fileC100 = CodeCov.File.Coverage(count: 1, covered: 1)
+    
+    static let fileA50Delta = CodeCov.File.Coverage(count: 2, covered: 1).delta(CodeCov.File.Coverage(count: 2, covered: 0))
+    static let fileB25Delta = CodeCov.File.Coverage(count: 4, covered: 1).delta(CodeCov.File.Coverage(count: 4, covered: 0))
+    static let fileC100Delta = CodeCov.File.Coverage(count: 1, covered: 1).delta(CodeCov.File.Coverage(count: 1, covered: 0))
+    
+    func testAsTableData_Sort_FilenameOrder() throws {
+        
+        let result = Self.testAggregate.asTableData(
+            includeDependencies: false,
+            projectName: nil,
+            sortOrder: .filename
+        )
+        
+        XCTAssertEqual(result.map { $0.filename }, [
+            "A.swift",
+            "B.swift",
+            "C.swift"
+        ])
+        
+    }
+    
+    func testAsTableData_Sort_CoverageAscOrder() throws {
+        
+        let result = Self.testAggregate.asTableData(
+            includeDependencies: false,
+            projectName: nil,
+            sortOrder: .coverageAsc
+        )
+        
+        XCTAssertEqual(result.map { $0.filename }, [
+            "B.swift",
+            "A.swift",
+            "C.swift"
+        ])
+        
+    }
+    
+    func testAsTableData_Sort_CoverageDescOrder() throws {
+        
+        let result = Self.testAggregate.asTableData(
+            includeDependencies: false,
+            projectName: nil,
+            sortOrder: .coverageDesc
+        )
+        
+        XCTAssertEqual(result.map { $0.filename }, [
+            "C.swift",
+            "A.swift",
+            "B.swift"
+        ])
+        
+    }
+    
+    func testAsTableData_WithDeltas() throws {
+        
+        let result = Self.testAggregateWithDeltas.asTableData(
+            includeDependencies: false,
+            projectName: nil,
+            sortOrder: .filename
+        )
+        
+        XCTAssertEqual(result, [
+            .testRow(filename: "A.swift", coverage: 50, delta: Self.fileA50Delta),
+            .testRow(filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
+            .testRow(filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
+        ])
+        
+    }
+    
+    func testAsTableData_WithDependencies() throws {
+        
+        let result = Self.testAggregate.asTableData(
+            includeDependencies: true,
+            projectName: "A",
+            sortOrder: .filename
+        )
+        
+        XCTAssertEqual(result, [
+            .testRow(dependency: false, filename: "A.swift", coverage: 50),
+            .testRow(dependency: true, filename: "B.swift", coverage: 25),
+            .testRow(dependency: true, filename: "C.swift", coverage: 100),
+        ])
+        
+    }
+    
+    func testAsTableData_WithDependenciesAndDeltas() throws {
+        
+        let result = Self.testAggregateWithDeltas.asTableData(
+            includeDependencies: true,
+            projectName: "B",
+            sortOrder: .filename
+        )
+        
+        XCTAssertEqual(result, [
+            .testRow(dependency: true, filename: "A.swift", coverage: 50, delta: Self.fileA50Delta),
+            .testRow(dependency: false, filename: "B.swift", coverage: 25, delta: Self.fileB25Delta),
+            .testRow(dependency: true, filename: "C.swift", coverage: 100, delta: Self.fileC100Delta),
+        ])
+        
+    }
+    
+}

--- a/Tests/SwiftTestCodecovLogicTests/Helpers/CoverageTableRowTestHelpers.swift
+++ b/Tests/SwiftTestCodecovLogicTests/Helpers/CoverageTableRowTestHelpers.swift
@@ -1,0 +1,28 @@
+//
+//  CoverageTableRowTestHelpers.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import Foundation
+@testable import SwiftTestCodecovLogic
+@testable import SwiftTestCodecovLib
+
+extension CoverageTableRow {
+
+    static func testRow(
+        dependency: Bool? = nil,
+        filename: String = "/Users/Test/myFile.swift",
+        coverage: Double = 95.00,
+        delta: CoverageDelta? = nil
+    ) -> CoverageTableRow {
+        CoverageTableRow(
+            dependency: dependency,
+            filename: filename,
+            coverage: coverage,
+            delta: delta
+        )
+    }
+
+}

--- a/Tests/SwiftTestCodecovLogicTests/TextTableHelpersTests.swift
+++ b/Tests/SwiftTestCodecovLogicTests/TextTableHelpersTests.swift
@@ -1,0 +1,24 @@
+//
+//  TextTableHelpersTests.swift
+//  
+//
+//  Created by Eric DeLabar on 12/12/22.
+//
+
+import XCTest
+import TextTable
+@testable import SwiftTestCodecovLib
+@testable import SwiftTestCodecovLogic
+
+final class ColumnExtensionsTests: XCTestCase {
+    
+    func testIncludeIf() throws {
+        
+        let cut = Column(title: "Title", value: "Value")
+        
+        XCTAssertNil(cut.includeIf(false))
+        XCTAssertNotNil(cut.includeIf(true))
+        
+    }
+    
+}

--- a/Tests/swift-test-codecovTests/PlaceholderTests2.swift
+++ b/Tests/swift-test-codecovTests/PlaceholderTests2.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Mathew Polzin on 8/1/19.
-//
-
-import Foundation


### PR DESCRIPTION
I wanted to unit test these changes and as I mentioned in #15 you can't do that in a command line executable. I could have moved all of the new logic to `SwiftTestCodecovLib`, but IMHO that package is for coverage output parsing and this was mostly display logic, so I created `SwiftTestCodecovLogic`, and everything in it is 100% covered. Other than that I don't feel strongly about this in any way, so if you want it as part of `SwiftTestCodecovLib` to keep the structure simpler, that's fine too.

I changed `Aggregate` by only adding fields, and most of them are optional. It does add the `coveredProperty` property to the default export, but I set that up so it'll still read old output without that field, it just assumes the `coveredProperty` is `lines`. Seemed like a reasonable compromise... 

Because I added fields to `Aggregate`, on a delta run, the JSON output will have the delta data in it. I chose to keep this because I thought it would be useful if the caller wanted to parse the JSON into HTML or something. Assuming normal JSON parsing the additional fields should just be ignored. I guess the only downside to this is a larger JSON output, which might be a problem for a larger project. I could add another option to not export deltas in JSON or maybe a different print format, but both seemed complicated because they only apply if the delta file is provided and it's all bordering on YAGNI.

Updated `--help` output is in the README.

### Example Output

(Non-delta output is the same, but here for reference.)

#### Minimal w/ Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format minimal --base-json-file base-coverage.json
```

```
89.66% (+10.34%)
```

#### Minimal w/o Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format minimal
```

```
89.66%
```

#### Table w/ Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format table --base-json-file base-coverage.json
```

```
Overall Coverage: 89.66% (+10.34%)

File              Coverage Coverage Change
----------------- -------- ---------------
Added.swift        100.00%         100.00%
Deleted.swift                    (Removed)
DeltaLess.swift     62.50%         -37.50%
DeltaMore.swift    100.00%         +54.55%
NoChange.swift     100.00%               -
                                          
=-=-=-=-=-=-=-=-=   
```

#### Table w/o Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format table
```

```
Overall Coverage: 89.66%

File              Coverage
----------------- --------
Added.swift        100.00%
DeltaLess.swift     62.50%
DeltaMore.swift    100.00%
NoChange.swift     100.00%
                          
=-=-=-=-=-=-=-=-=  
```

#### Numeric Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format numeric --base-json-file base-coverage.json
```

This returns the delta and not the total coverage. I don't have a particular use case for this, so no real opinion other than if you wanted the total coverage you could just run it again without the delta file. 🤷‍♂️

```
10.344827586206895
```

#### Numeric

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format numeric
```

```
89.65517241379311
```

#### JSON w/ Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format json --base-json-file base-coverage.json
```

(Formatted and reordered for clarity)

``` javascript
{
  "coveragePerFile": {
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/NoChange.swift": {
      "count": 5,
      "covered": 5,
      "percent": 100
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaMore.swift": {
      "count": 11,
      "covered": 11,
      "percent": 100
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaLess.swift": {
      "count": 8,
      "covered": 5,
      "percent": 62.5
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/Added.swift": {
      "count": 5,
      "covered": 5,
      "percent": 100
    }
  },
  "coverageDeltaPerFile": {
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/NoChange.swift": {
      "noChange": {}
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaMore.swift": {
      "delta": {
        "coverageChange": {
          "count": 0,
          "covered": 6,
          "percent": 54.54545454545455
        }
      }
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaLess.swift": {
      "delta": {
        "coverageChange": {
          "count": 0,
          "covered": -3,
          "percent": -37.5
        }
      }
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/Deleted.swift": {
      "fileRemoved": {}
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/Added.swift": {
      "fileAdded": {
        "newCoverage": {
          "count": 5,
          "covered": 5,
          "percent": 100
        }
      }
    }
  },
  "totalCount": 29,
  "totalCountDelta": 0,
  "overallCoverage": 0.896551724137931,
  "overallCoverageDelta": 0.10344827586206895,
  "coveredProperty": "lines"
}
```

#### JSON w/o Delta

``` bash
$ swift-test-codecov .build/debug/codecov/CoverageExample.json --print-format json
```

(Formatted and reordered for clarity)

``` javascript
{
  "coveragePerFile": {
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaMore.swift": {
      "count": 11,
      "covered": 11,
      "percent": 100
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/NoChange.swift": {
      "count": 5,
      "covered": 5,
      "percent": 100
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/DeltaLess.swift": {
      "count": 8,
      "covered": 5,
      "percent": 62.5
    },
    "/Users/edelabar/Code/projects/CoverageExample/Sources/CoverageExample/Added.swift": {
      "count": 5,
      "covered": 5,
      "percent": 100
    }
  },
  "totalCount": 29,
  "overallCoverage": 0.896551724137931,
  "coveredProperty": "lines"
}
```