### PR TITLE
Fix test file identification.

### DIFF
--- a/Sources/SwiftTestCodecovLib/Aggregate.swift
+++ b/Sources/SwiftTestCodecovLib/Aggregate.swift
@@ -62,7 +62,9 @@ public struct Aggregate: Encodable {
             var nonTestDataSet = [CodeCov.Data]()
             for datum in coverage.data {
                 let nonTestFiles = datum.files.filter({ file in
-                    !(file.filename.lowercased().contains("test"))
+                    let inTestsFolder = file.filename.lowercased().contains("/tests/")
+                    let isTestFile = file.filename.lowercased().contains("tests.swift")
+                    return !inTestsFolder || !isTestFile
                 })
                 // If all files in this data instance were tests, ignore it altogether. Else add it to the array.
                 if !nonTestFiles.isEmpty {


### PR DESCRIPTION
The tool was inaccurately identifying files from itself as tests based on the flawed test file check. The new check is a bit more targeted but I think still effective.