### PR TITLE
Allow floating point minimum code coverage numbers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.4.3 as builder
+FROM swift:5.7 as builder
 
 WORKDIR /build
 RUN git clone https://github.com/mattpolzin/swift-test-codecov.git
@@ -7,7 +7,7 @@ WORKDIR swift-test-codecov
 RUN git checkout main \
  && swift build
 
-FROM swift:5.4.3-slim
+FROM swift:5.7-slim
 
 COPY --from=builder /build/swift-test-codecov/.build/debug/swift-test-codecov /usr/bin/swift-test-codecov
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OPTIONS:
         If specified, used to determine which source files being tested are outside of this project (local dependencies).
   -m, --metric <metric>   The metric over which to aggregate. One of lines, functions, instantiations (default: lines)
   -v, --minimum <minimum-coverage>
-                          The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0)
+                          The minimum coverage percentage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1. (default: 0.0)
   --explain-failure/--no-explain-failure
                           Determines whether a message will be displayed if the minimum coverage threshold was not met. (The `json` print-format will never display messages and will always be parsable
                           JSON.) (default: true)

--- a/Sources/swift-test-codecov/main.swift
+++ b/Sources/swift-test-codecov/main.swift
@@ -65,11 +65,11 @@ struct StatsCommand: ParsableCommand {
     @Option(
         name: [.customLong("minimum"), .customShort("v")],
         help: ArgumentHelp(
-            "The minimum coverage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1.",
+            "The minimum coverage percentage allowed. A value between 0 and 100. Coverage below the minimum will result in exit code 1.",
             valueName: "minimum-coverage"
         )
     )
-    var minimumCoverage: Int = 0
+    var minimumCoverage: Double = 0
     
     @Flag(
         name: [.customLong("explain-failure")],
@@ -126,7 +126,7 @@ struct StatsCommand: ParsableCommand {
     var warnMissingTests: Bool = true
     
     func validate() throws {
-        guard (0...100).contains(minimumCoverage) else {
+        if minimumCoverage < 0 || minimumCoverage > 100 {
             throw ValidationError("Minimum coverage must be between 0 and 100 because it represents a percentage.")
         }
     }
@@ -134,7 +134,6 @@ struct StatsCommand: ParsableCommand {
     func run() throws {
 
         let aggProperty: CodeCov.AggregateProperty = metric
-        let minimumCov = minimumCoverage
 
         let data = try! Data(contentsOf: URL(fileURLWithPath: codecovFile))
 
@@ -166,12 +165,12 @@ struct StatsCommand: ParsableCommand {
             print("Double check that you are either running this tool from the root of your target project or else you've specified a project-name that has the exact name of the root folder of your target project -- otherwise, all files may be filtered out as belonging to other projects (dependencies).")
         }
 
-        let passed = aggregateCoverage.overallCoveragePercent > Double(minimumCov)
+        let passed = aggregateCoverage.overallCoveragePercent >= minimumCoverage
 
         if !passed && printFormat != .json && explainFailure {
             // we don't print the error message out for the minimal or JSON formats.
             print("")
-            print("The overall coverage did not meet the minimum threshold of \(minimumCov)%")
+            print("The overall coverage did not meet the minimum threshold of \(minimumCoverage)%")
         }
 
         printResults(aggregateCoverage)


### PR DESCRIPTION
Closes https://github.com/mattpolzin/swift-test-codecov/issues/20.